### PR TITLE
Exclude from grouping in Renovate due to a bug in Rolldown.

### DIFF
--- a/update-action-readme/src/run.ts
+++ b/update-action-readme/src/run.ts
@@ -26,9 +26,7 @@ export const run = async (inputs: Inputs) => {
   ok(headRef, "Expected head ref");
   await git.fetch(inputs.cwd, inputs.token, base, head);
   await git.checkout(inputs.cwd, head);
-
   const { packages } = await getPackages(inputs.cwd);
-
   for (const pkg of packages) {
     const readmePath = join(pkg.dir, "README.md");
     if (!existsSync(readmePath)) continue;
@@ -39,7 +37,6 @@ export const run = async (inputs: Inputs) => {
     const actionYaml = parse(
       await readFile(actionYamlPath, "utf-8"),
     ) as GithubAction;
-
     // update action version
     const updatedReadme = updateReadme({
       readme,
@@ -49,25 +46,20 @@ export const run = async (inputs: Inputs) => {
       })),
       actionYaml,
     });
-
     await writeFile(readmePath, updatedReadme);
   }
-
   // if git status is dirty, commit and push
   if (!(await git.isDirty(inputs.cwd))) {
     info("No changes");
     return;
   }
-
   if (inputs["setup-git-user"]) {
     await git.configure(inputs.cwd);
   }
-
   // commit, pull --rebase and push
   await git.commitAll(inputs.cwd, "chore: update readme");
   await git.pullRebase(inputs.cwd, inputs.token, headRef);
   await git.push(inputs.cwd, inputs.token, headRef, true);
-
   // pr should be updated, so this action should be failed
   throw new Error("some files are updated, this PR should be updated");
 };


### PR DESCRIPTION
rolldown v0.15.0 has a bug like this. v0.14.0 has not.

```txt
> update-action-readme@0.0.17 build /home/runner/work/actions/actions/update-action-readme
> rolldown -c rolldown.config.mjs

thread '<unnamed>' panicked at crates/rolldown_common/src/types/symbol_ref_db.rs:[14](https://github.com/YutaUra/actions/actions/runs/12329789570/job/34414514763?pr=48#step:9:15)8:7:
canonical name not found for SymbolRef { owner: 389, symbol: SymbolId(0) }, original_name: "node_process"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^

[Error: Panic in async function] { code: 'GenericFailure' }

Node.js v22.12.0
```